### PR TITLE
Now accepting options object for decode/encode

### DIFF
--- a/test/uuid-base62.test.js
+++ b/test/uuid-base62.test.js
@@ -46,7 +46,7 @@ describe('uuid-base62', function () {
       assert.equal(res, uuid);
     });
   });
-  
+
   describe('v1', function () {
     it('should generate a unique id without any params', function () {
       var res = uuidBase62.v1();
@@ -55,28 +55,44 @@ describe('uuid-base62', function () {
       assert.equal(res.length, 22);
     });
   });
-  
+
   describe('encode / decode', function () {
     var fixtures = {
       '0000000000000000000000': '00000000-0000-0000-0000-000000000000',
       '0cBaidlJ84Ggc5JA7IYCgv': '06ad547f-fe02-477b-9473-f7977e4d5e17',
       '4vqyd6OoARXqj9nRUNhtLQ': '941532a0-6be1-443a-a9d5-d57bdf180a52',
-      '5FY8KwTsQaUJ2KzHJGetfE': 'ba86b8f0-6fdf-4944-87a0-8a491a19490e',      
+      '5FY8KwTsQaUJ2KzHJGetfE': 'ba86b8f0-6fdf-4944-87a0-8a491a19490e',
       '7N42dgm5tFLK9N8MT7fHC7': 'ffffffff-ffff-ffff-ffff-ffffffffffff'
     };
-    
+
     Object.keys(fixtures).forEach(function(key){
       it('should properly encode ' + fixtures[key], function () {
         assert.equal(uuidBase62.encode(fixtures[key]), key);
       });
-      
+
       it('should properly decode ' + key, function () {
         assert.equal(uuidBase62.decode(key), fixtures[key]);
       });
     });
+
+    it('should properly encode/decode with a different encoding', function () {
+      assert.equal(uuidBase62.encode('06ad547f-fe02-477b-9473-f7977e4d5e17', {encoding: 'ascii'}), 'bqP6JWAS4t1lWczmmHbPIhwMSO27BW1qKdDPx2mTN5l');
+      assert.equal(uuidBase62.decode('bqP6JWAS4t1lWczmmHbPIhwMSO27BW1qKdDPx2mTN5l', {encoding: 'ascii'}), '06ad547f-fe02-477b-9473-f7977e4d5e17');
+    });
   });
-  
+
   describe('other bases', function () {
+    it('should accept a custom base as an option', function () {
+      var customBase = new uuidBase62.baseX("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_");
+      var uuid = '72be7291-fbf6-400f-87c4-455e23d01cd5';
+
+      var uuidB64 = uuidBase62.encode(uuid, {base: customBase});
+      assert.equal(uuidB64, '1OLDah-_p03Uv4hlUzQ1Pl');
+
+      var res = uuidBase62.decode(uuidB64, {base: customBase});
+      assert.equal(res, uuid);
+    });
+
     it('should generate a unique id without any params in base64', function () {
       uuidBase62.customBase = new uuidBase62.baseX("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_");
       var res = uuidBase62.v4();
@@ -91,7 +107,7 @@ describe('uuid-base62', function () {
 
       var uuidB64 = uuidBase62.encode(uuid);
       assert.equal(uuidB64, '1OLDah-_p03Uv4hlUzQ1Pl');
-      
+
       var res = uuidBase62.decode(uuidB64);
       assert.equal(res, uuid);
     });

--- a/uuid-base62.js
+++ b/uuid-base62.js
@@ -49,23 +49,40 @@ module.exports.v1 = function v1() {
 /**
  * encode
  */
-module.exports.encode = function encode(input, encoding) {
-  encoding = encoding || 'hex';
-  
+module.exports.encode = function encode(input, options) {
+  options = options || {};
+
+  // Make compatible with previous API.
+  options.encoding = typeof options === 'string' ?
+    options
+  : options.encoding || 'hex';
+
+  options.base = options.base || this.customBase;
+  options.length = options.length || module.exports.length;
+
   if (typeof input === 'string') {
     // remove the dashes to save some space
-    input = new Buffer(input.replace(/-/g, ''), encoding);
+    input = new Buffer(input.replace(/-/g, ''), options.encoding);
   }
-  return ensureLength(this.customBase.encode(input), module.exports.length);
+  return ensureLength(options.base.encode(input), options.length);
 };
 
 /**
  * decode
  */
-module.exports.decode = function decode(b62Str, encoding) {
-  encoding = encoding || 'hex';
-  var res = ensureLength(new Buffer(this.customBase.decode(b62Str)).toString(encoding), module.exports.uuidLength);
-  
+module.exports.decode = function decode(b62Str, options) {
+  options = options || {};
+
+  // Make compatible with previous API.
+  options.encoding = typeof options === 'string' ?
+    options
+  : options.encoding || 'hex';
+
+  options.base = options.base || this.customBase;
+  options.length = options.length || module.exports.uuidLength;
+
+  var res = ensureLength(new Buffer(options.base.decode(b62Str)).toString(options.encoding), options.length);
+
   // re-add the dashes so the result looks like an uuid
   var resArray = res.split('');
   [8, 13, 18, 23].forEach(function(idx){
@@ -78,7 +95,7 @@ module.exports.decode = function decode(b62Str, encoding) {
 
 /**
  * ensureLength
- * 
+ *
  * @api private
  */
 function ensureLength(str, maxLen){
@@ -95,7 +112,7 @@ function ensureLength(str, maxLen){
 
 /**
  * padLeft
- * 
+ *
  * @api private
  */
 function padLeft(str, padding){
@@ -109,7 +126,7 @@ function padLeft(str, padding){
 
 /**
  * trimLeft
- * 
+ *
  * @api private
  */
 function trimLeft(str, maxLen){


### PR DESCRIPTION
I think that is a better approach than relying on the module state, would it be a welcome change? It's also backwards compatible with the current API. Some of the diff changes are my editor striping out extraneous whitespace.